### PR TITLE
Add ci cd from travis

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,16 @@
+# Private AWS configuration parameters to be used locally and for deployment by node-lambda
+AWS_ENVIRONMENT=development
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_PROFILE=
+AWS_SESSION_TOKEN=
+AWS_ROLE_ARN=
+AWS_REGION=us-east-1
+AWS_HANDLER=index.handler
+AWS_MEMORY_SIZE=768
+AWS_TIMEOUT=30
+AWS_DESCRIPTION=
+AWS_RUNTIME=nodejs6.10
+EXCLUDE_GLOBS="*.env,event.json"
+PACKAGE_DIRECTORY=build
+# These parameters should be left in plain text

--- a/.env
+++ b/.env
@@ -3,8 +3,6 @@ AWS_REGION=us-east-1
 AWS_HANDLER=index.handler
 AWS_MEMORY_SIZE=768
 AWS_TIMEOUT=30
-AWS_DESCRIPTION=
 AWS_RUNTIME=nodejs6.10
 EXCLUDE_GLOBS="*.env,event.json"
 PACKAGE_DIRECTORY=build
-# These parameters should be left in plain text

--- a/.env
+++ b/.env
@@ -1,10 +1,4 @@
 # Private AWS configuration parameters to be used locally and for deployment by node-lambda
-AWS_ENVIRONMENT=development
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-AWS_PROFILE=
-AWS_SESSION_TOKEN=
-AWS_ROLE_ARN=
 AWS_REGION=us-east-1
 AWS_HANDLER=index.handler
 AWS_MEMORY_SIZE=768

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-.env
 composer.phar
-config/var_development.env
-config/var_production.env
 config/var_app
 vendor/
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,37 @@
-language: php
+language:
+- php
+- node_js
 php:
-  - 7.1
+- 7.1
+node_js:
+- 6.1
+cache:
+  directories:
+  - node_modules
+install:
+- npm install
 script:
-  - composer update
-  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+- composer update
+- vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 after_success:
-  - vendor/bin/coveralls -v
-  - vendor/bin/phpcs -n --standard=PSR1,PSR2 src/
-  - vendor/bin/phpcbf src/
+- vendor/bin/coveralls -v
+- vendor/bin/phpcs -n --standard=PSR1,PSR2 src/
+- vendor/bin/phpcbf src/
+deploy:
+- provider: script
+  skip_cleanup: true
+  script: npm run deploy-production
+  on:
+    branch: master
+- provider: script
+  skip_cleanup: true
+  script: npm run deploy-development
+  on:
+    branch: development
+after_deploy: echo 'Successfully executed deploy trigger for Checkout Request Service
+  on AWS'
+env:
+  global:
+  - secure: nsMR8o7rTsFYSQpuv0TcCH7prkmT63v9m15wslTjPfCIQRW9wLBFgXXxcIuMt8IprzqDxIJXmNm/ftvR082mMG/glB23aoBBqjnd3CFnRvFR5REZOuT7o5aWMGz2nx2WyrvNv9yjh5iQUL4xTBTbRJoSPZN2906g/RVNZthAP/MeivE8BcH5JNpXOZIHnB8zg75kWVrlTflZVcqn936DNRPyTqZtp3BPzG16ASz/O5tfPLyIPR1ZRcSEqQ8SCmqNan/UU8PRk4WWGbsTgqMKaJK1WCVra61q1mRNWOWX1sQog7BC5mxSSqIlAUJoiC0fxYUsQI5UJkPwwhQMu/vQajIkwqiWJteik8FTc0MNo3MBteYBmlqnZ7osxhBL8bFPnnsyL/HlUMBy1xg7Hs/aWPU/HP9/QJQBwx8Vps0oyVHNn0XAdES6gxJK1TH3gzHHBXq3HSSnxv/6pwAUjFgqKUMws7dDyZvUR59X/iL7rd1MYKZXGt4RbmP8JigsRuTBcKjRjcRbalhdsluenfuuvagKogX91eb1uZHawE/cM06V3dV38iViQhWjXLVsLvmKcpsJCitpK5fxbSmHWtP9sjyz8aKu7U9hEUTchHkPOTCt6Qqt7gpffLHbPl5zTMt/exjP/ojFDzjQ+RXrq807UDbIyoIiOE4tZ5y898ssfpE=
+  - secure: T/1FPx5duDowLXNCGYzdFTmyIrk4OSoKxGvPdEfKB1kvoZxDGKqeGu96RGoAmfKcmECHeB0vf8+/UJcaLkWRshhP8ollGTr3FnZtj+6CWyxEVudwnCi/GjSGWmIPRAw0bF6UQqFcedN+ubIKIBT3nJYPApE4mdYXrSPOp5usm9mcSr8/5VhNzCfMo7wQqtsQ5O7e+nPO3pg8HJUc8ulGWaCAFO4RHKlqO0U2jekMMp+ISSKx6DfRDwc6DznRfMHfAR74Z45oGpowgyv6Ql7b71u7+f74RlR1LOYkrtxZrnTRa2JbBQOLh0ynn5vOH9A323j3529aYV6DCNqlF7quU1x6GHNINaX5jV0T9/MRQRYglgHZKTNhMqjvKFnjgCHIQBiIbC6DQV9/gkGn057W/SNzxbK20ULxxMG34hxJL/jC5XwTznZbF43WpEB7kDgL/5qJscCPImvlahUFenbqWjTt/zFTkR7BDVhjAI06WXrVEgjOBaLFy9vADH66Ljulk/DU4F+DrK8ZlgtaYJKqTJ6V21dvMIikt+X+UGbVEed2E1uoj5X/p+j3yXbzjcI/GeA3DMC59wCPaXtNE3G6N8P3470YICXqmHDjbNT6mrc1d7raknKknT27CT/Vi61rABE7aRes1HiVhLgXBLMLIEqofwCMz1Jk5JG0PdbOEJE=
+  - secure: bMBoLf6u+Q7IYri8/WdPdScpEwOSUG5FcuYLuYSlmtPCj/YuSzIRzahy6ysVw1szLpR7JsXDRk0N5iHNN8riuVqmv92AB/+uj8Qg3siUL0N6oUVqFShevS8XrBR0LddNgkw1llnwRPBVfIHpOL9LioYvJOEN4jTV2KQZp7ZrNIiRsjBZUf0PIBwZ4Q/VVlFkVXe8+9QoU8lsrjG0ZP+WDrWHzdydxpqbCSNOPX6hsDbKEch+r86q846ASq5WIgH0pkNViHawqc/CnXjlrb7zxrNWex5yl++Kp2Vdj0EDF67hzf3G4Nx0bBGR6NPq69EVdWLfXHmhAYXfKDx7eSI09Kh59m0l7XN1jU0x1kwOLa3Lle4M0eu33su+faBKo1DNgTglmr1hqp34kIsDKC+g3WOZTVpotc9RgF5nbHLlooDFxrsuL20ycdgpukRvD/7uyvYrqz2db1E4mhb5KzAlYj8IA0hSksCwzuo8EQX1LEWlccQr/4AV+lHjYJRUV3XeuN0P4SH9qkoJyP8TuECxG+x4XNe/8W8SQW0/XnVjXYpvbsdVuMp5owgER70VBJQm9+Iss/lCKggI7LFIHo6Ox9yQWeyv3OlmlrktJQSu17l1f89BcwK0sB0mtUydfLRGwvmEf+bSrjcXRPhJcBeIaYQFbaM1UOC2rft/g0roavI=

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ after_success:
   - if [ '$TRAVIS_BRANCH' == 'master' ]; then ENVIRONMENT_NAME=production; fi
 deploy:
   - provider: script
-  skip_cleanup: true
-  script: "./scripts/travis-deploy.sh $ENVIRONMENT_NAME"
-  on:
-    all_branches: true
-    condition: "$ENVIRONMENT_NAME =~ ^(development|qa|production)$"
+    skip_cleanup: true
+    script: './scripts/travis-deploy.sh $ENVIRONMENT_NAME'
+    on:
+      all_branches: true
+      condition: '$ENVIRONMENT_NAME =~ ^(development|qa|production)$'
 after_deploy: echo 'Successfully executed deploy trigger for Checkout Request Service
   on AWS'
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,35 @@
 language:
-- php
-- node_js
+  - php
+  - node_js
 php:
-- 7.1
+  - 7.1
 node_js:
-- 6.1
+  - 6.1
 cache:
   directories:
-  - node_modules
+    - node_modules
 install:
-- npm install
+  - npm install
 script:
-- composer update
-- vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+  - composer update
+  - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 after_success:
-- vendor/bin/coveralls -v
-- vendor/bin/phpcs -n --standard=PSR1,PSR2 src/
-- vendor/bin/phpcbf src/
+  - vendor/bin/coveralls -v
+  - vendor/bin/phpcs -n --standard=PSR1,PSR2 src/
+  - vendor/bin/phpcbf src/
+  - ENVIRONMENT_NAME=$TRAVIS_BRANCH
+  - if [ '$TRAVIS_BRANCH' == 'master' ]; then ENVIRONMENT_NAME=production; fi
 deploy:
-- provider: script
+  - provider: script
   skip_cleanup: true
-  script: npm run deploy-production
+  script: "./scripts/travis-deploy.sh $ENVIRONMENT_NAME"
   on:
-    branch: master
-- provider: script
-  skip_cleanup: true
-  script: npm run deploy-development
-  on:
-    branch: development
+    all_branches: true
+    condition: "$ENVIRONMENT_NAME =~ ^(development|qa|production)$"
 after_deploy: echo 'Successfully executed deploy trigger for Checkout Request Service
   on AWS'
 env:
   global:
-  - secure: nsMR8o7rTsFYSQpuv0TcCH7prkmT63v9m15wslTjPfCIQRW9wLBFgXXxcIuMt8IprzqDxIJXmNm/ftvR082mMG/glB23aoBBqjnd3CFnRvFR5REZOuT7o5aWMGz2nx2WyrvNv9yjh5iQUL4xTBTbRJoSPZN2906g/RVNZthAP/MeivE8BcH5JNpXOZIHnB8zg75kWVrlTflZVcqn936DNRPyTqZtp3BPzG16ASz/O5tfPLyIPR1ZRcSEqQ8SCmqNan/UU8PRk4WWGbsTgqMKaJK1WCVra61q1mRNWOWX1sQog7BC5mxSSqIlAUJoiC0fxYUsQI5UJkPwwhQMu/vQajIkwqiWJteik8FTc0MNo3MBteYBmlqnZ7osxhBL8bFPnnsyL/HlUMBy1xg7Hs/aWPU/HP9/QJQBwx8Vps0oyVHNn0XAdES6gxJK1TH3gzHHBXq3HSSnxv/6pwAUjFgqKUMws7dDyZvUR59X/iL7rd1MYKZXGt4RbmP8JigsRuTBcKjRjcRbalhdsluenfuuvagKogX91eb1uZHawE/cM06V3dV38iViQhWjXLVsLvmKcpsJCitpK5fxbSmHWtP9sjyz8aKu7U9hEUTchHkPOTCt6Qqt7gpffLHbPl5zTMt/exjP/ojFDzjQ+RXrq807UDbIyoIiOE4tZ5y898ssfpE=
-  - secure: T/1FPx5duDowLXNCGYzdFTmyIrk4OSoKxGvPdEfKB1kvoZxDGKqeGu96RGoAmfKcmECHeB0vf8+/UJcaLkWRshhP8ollGTr3FnZtj+6CWyxEVudwnCi/GjSGWmIPRAw0bF6UQqFcedN+ubIKIBT3nJYPApE4mdYXrSPOp5usm9mcSr8/5VhNzCfMo7wQqtsQ5O7e+nPO3pg8HJUc8ulGWaCAFO4RHKlqO0U2jekMMp+ISSKx6DfRDwc6DznRfMHfAR74Z45oGpowgyv6Ql7b71u7+f74RlR1LOYkrtxZrnTRa2JbBQOLh0ynn5vOH9A323j3529aYV6DCNqlF7quU1x6GHNINaX5jV0T9/MRQRYglgHZKTNhMqjvKFnjgCHIQBiIbC6DQV9/gkGn057W/SNzxbK20ULxxMG34hxJL/jC5XwTznZbF43WpEB7kDgL/5qJscCPImvlahUFenbqWjTt/zFTkR7BDVhjAI06WXrVEgjOBaLFy9vADH66Ljulk/DU4F+DrK8ZlgtaYJKqTJ6V21dvMIikt+X+UGbVEed2E1uoj5X/p+j3yXbzjcI/GeA3DMC59wCPaXtNE3G6N8P3470YICXqmHDjbNT6mrc1d7raknKknT27CT/Vi61rABE7aRes1HiVhLgXBLMLIEqofwCMz1Jk5JG0PdbOEJE=
-  - secure: bMBoLf6u+Q7IYri8/WdPdScpEwOSUG5FcuYLuYSlmtPCj/YuSzIRzahy6ysVw1szLpR7JsXDRk0N5iHNN8riuVqmv92AB/+uj8Qg3siUL0N6oUVqFShevS8XrBR0LddNgkw1llnwRPBVfIHpOL9LioYvJOEN4jTV2KQZp7ZrNIiRsjBZUf0PIBwZ4Q/VVlFkVXe8+9QoU8lsrjG0ZP+WDrWHzdydxpqbCSNOPX6hsDbKEch+r86q846ASq5WIgH0pkNViHawqc/CnXjlrb7zxrNWex5yl++Kp2Vdj0EDF67hzf3G4Nx0bBGR6NPq69EVdWLfXHmhAYXfKDx7eSI09Kh59m0l7XN1jU0x1kwOLa3Lle4M0eu33su+faBKo1DNgTglmr1hqp34kIsDKC+g3WOZTVpotc9RgF5nbHLlooDFxrsuL20ycdgpukRvD/7uyvYrqz2db1E4mhb5KzAlYj8IA0hSksCwzuo8EQX1LEWlccQr/4AV+lHjYJRUV3XeuN0P4SH9qkoJyP8TuECxG+x4XNe/8W8SQW0/XnVjXYpvbsdVuMp5owgER70VBJQm9+Iss/lCKggI7LFIHo6Ox9yQWeyv3OlmlrktJQSu17l1f89BcwK0sB0mtUydfLRGwvmEf+bSrjcXRPhJcBeIaYQFbaM1UOC2rft/g0roavI=
+    - secure: nsMR8o7rTsFYSQpuv0TcCH7prkmT63v9m15wslTjPfCIQRW9wLBFgXXxcIuMt8IprzqDxIJXmNm/ftvR082mMG/glB23aoBBqjnd3CFnRvFR5REZOuT7o5aWMGz2nx2WyrvNv9yjh5iQUL4xTBTbRJoSPZN2906g/RVNZthAP/MeivE8BcH5JNpXOZIHnB8zg75kWVrlTflZVcqn936DNRPyTqZtp3BPzG16ASz/O5tfPLyIPR1ZRcSEqQ8SCmqNan/UU8PRk4WWGbsTgqMKaJK1WCVra61q1mRNWOWX1sQog7BC5mxSSqIlAUJoiC0fxYUsQI5UJkPwwhQMu/vQajIkwqiWJteik8FTc0MNo3MBteYBmlqnZ7osxhBL8bFPnnsyL/HlUMBy1xg7Hs/aWPU/HP9/QJQBwx8Vps0oyVHNn0XAdES6gxJK1TH3gzHHBXq3HSSnxv/6pwAUjFgqKUMws7dDyZvUR59X/iL7rd1MYKZXGt4RbmP8JigsRuTBcKjRjcRbalhdsluenfuuvagKogX91eb1uZHawE/cM06V3dV38iViQhWjXLVsLvmKcpsJCitpK5fxbSmHWtP9sjyz8aKu7U9hEUTchHkPOTCt6Qqt7gpffLHbPl5zTMt/exjP/ojFDzjQ+RXrq807UDbIyoIiOE4tZ5y898ssfpE=
+    - secure: T/1FPx5duDowLXNCGYzdFTmyIrk4OSoKxGvPdEfKB1kvoZxDGKqeGu96RGoAmfKcmECHeB0vf8+/UJcaLkWRshhP8ollGTr3FnZtj+6CWyxEVudwnCi/GjSGWmIPRAw0bF6UQqFcedN+ubIKIBT3nJYPApE4mdYXrSPOp5usm9mcSr8/5VhNzCfMo7wQqtsQ5O7e+nPO3pg8HJUc8ulGWaCAFO4RHKlqO0U2jekMMp+ISSKx6DfRDwc6DznRfMHfAR74Z45oGpowgyv6Ql7b71u7+f74RlR1LOYkrtxZrnTRa2JbBQOLh0ynn5vOH9A323j3529aYV6DCNqlF7quU1x6GHNINaX5jV0T9/MRQRYglgHZKTNhMqjvKFnjgCHIQBiIbC6DQV9/gkGn057W/SNzxbK20ULxxMG34hxJL/jC5XwTznZbF43WpEB7kDgL/5qJscCPImvlahUFenbqWjTt/zFTkR7BDVhjAI06WXrVEgjOBaLFy9vADH66Ljulk/DU4F+DrK8ZlgtaYJKqTJ6V21dvMIikt+X+UGbVEed2E1uoj5X/p+j3yXbzjcI/GeA3DMC59wCPaXtNE3G6N8P3470YICXqmHDjbNT6mrc1d7raknKknT27CT/Vi61rABE7aRes1HiVhLgXBLMLIEqofwCMz1Jk5JG0PdbOEJE=
+    - secure: bMBoLf6u+Q7IYri8/WdPdScpEwOSUG5FcuYLuYSlmtPCj/YuSzIRzahy6ysVw1szLpR7JsXDRk0N5iHNN8riuVqmv92AB/+uj8Qg3siUL0N6oUVqFShevS8XrBR0LddNgkw1llnwRPBVfIHpOL9LioYvJOEN4jTV2KQZp7ZrNIiRsjBZUf0PIBwZ4Q/VVlFkVXe8+9QoU8lsrjG0ZP+WDrWHzdydxpqbCSNOPX6hsDbKEch+r86q846ASq5WIgH0pkNViHawqc/CnXjlrb7zxrNWex5yl++Kp2Vdj0EDF67hzf3G4Nx0bBGR6NPq69EVdWLfXHmhAYXfKDx7eSI09Kh59m0l7XN1jU0x1kwOLa3Lle4M0eu33su+faBKo1DNgTglmr1hqp34kIsDKC+g3WOZTVpotc9RgF5nbHLlooDFxrsuL20ycdgpukRvD/7uyvYrqz2db1E4mhb5KzAlYj8IA0hSksCwzuo8EQX1LEWlccQr/4AV+lHjYJRUV3XeuN0P4SH9qkoJyP8TuECxG+x4XNe/8W8SQW0/XnVjXYpvbsdVuMp5owgER70VBJQm9+Iss/lCKggI7LFIHo6Ox9yQWeyv3OlmlrktJQSu17l1f89BcwK0sB0mtUydfLRGwvmEf+bSrjcXRPhJcBeIaYQFbaM1UOC2rft/g0roavI=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### 0.2.0
+> Add the configurations for CI/CD with Travis.
+
 ### 0.1.1
 > Add .gitignore.
 > Remove the trailing coma in package.json

--- a/README.md
+++ b/README.md
@@ -138,6 +138,3 @@ or simply git push the `development` or `master` branch. The branch will be depl
 
 development => CheckinRequestService-development (nypl-sandbox)
 master => CheckinRequestService-production(nypl-digital-dev)
-
-We use `scripts/travis-deploy.sh` for Travis to run deployment. Make sure you have enabled `scripts/travis-deploy.sh` before commiting by run `chmod +x ./scripts/travis-deploy.sh`.
-

--- a/README.md
+++ b/README.md
@@ -133,3 +133,9 @@ To deploy to an environment, run the corresponding command. For example:
 ~~~~
 npm run deploy-development
 ~~~~
+
+or simply git push the `development` or `master` branch. The branch will be deployed respectively with Travis.
+
+development => CheckinRequestService-development (nypl-sandbox)
+master => CheckinRequestService-production(nypl-digital-dev)
+

--- a/README.md
+++ b/README.md
@@ -139,3 +139,5 @@ or simply git push the `development` or `master` branch. The branch will be depl
 development => CheckinRequestService-development (nypl-sandbox)
 master => CheckinRequestService-production(nypl-digital-dev)
 
+We use `scripts/travis-deploy.sh` for Travis to run deployment. Make sure you have enabled `scripts/travis-deploy.sh` before commiting by run `chmod +x ./scripts/travis-deploy.js`.
+

--- a/README.md
+++ b/README.md
@@ -139,5 +139,5 @@ or simply git push the `development` or `master` branch. The branch will be depl
 development => CheckinRequestService-development (nypl-sandbox)
 master => CheckinRequestService-production(nypl-digital-dev)
 
-We use `scripts/travis-deploy.sh` for Travis to run deployment. Make sure you have enabled `scripts/travis-deploy.sh` before commiting by run `chmod +x ./scripts/travis-deploy.js`.
+We use `scripts/travis-deploy.sh` for Travis to run deployment. Make sure you have enabled `scripts/travis-deploy.sh` before commiting by run `chmod +x ./scripts/travis-deploy.sh`.
 

--- a/config/var_development.env
+++ b/config/var_development.env
@@ -1,0 +1,20 @@
+SLACK_TOKEN=AQECAHjqALewp8JBJNxIQvR4oY795dyG7INaGR1glMsTEgetggAAAIgwgYUGCSqGSIb3DQEHBqB4MHYCAQAwcQYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAwUxu/7g52ACSN8xswCARCARBtDGIawtP9YsiJAJmSn0Sz2yFKxHvisLFz3EYv9KWvJNRIJwG0yITOmYchDRmu7K62i7HCGuDikFfP8BMdw2kuovYng
+DB_PASSWORD=AQECAHjqALewp8JBJNxIQvR4oY795dyG7INaGR1glMsTEgetggAAAGkwZwYJKoZIhvcNAQcGoFowWAIBADBTBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDH2FhATxg5+YzshVzwIBEIAms31wFMFh70BYaJw6UP4Ii8jBYBgWQkWI9DYnYQyJEeKSWvgLz4s=
+DB_USERNAME=apiservice
+# These parameters should be left in plain text
+DB_CONNECT_STRING=pgsql:host=nypl-cancel-requests.cicyc5fazypj.us-east-1.rds.amazonaws.com;dbname=cancel_requests
+NCIP_URL=AQECAHjqALewp8JBJNxIQvR4oY795dyG7INaGR1glMsTEgetggAAAJgwgZUGCSqGSIb3DQEHBqCBhzCBhAIBADB/BgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDKd2GiO78OXvU8UpgQIBEIBS2y4tbUHfF/VZThgb/I/3Me2t5o2yDsf+GrIcEcsXeoO1AOYM3uMokK3P+Q2gVaM2b5SZFZj0oel7uMkwiUJvmiyj7yYaKm700DUN/ZMFE9x+Sw==
+SLACK_CHANNEL=service-logging
+SLACK_CHANNEL_ALT=cancel-req-logging
+SLACK_USERNAME=CheckoutRequestService-development
+SLACK_LOGGING_LEVEL=info
+DEFAULT_LOGGING_LEVEL=debug
+JOB_SERVICE_URL=https://dev-platform.nypl.org/api/v0.1/jobs
+USE_JOB_SERVICE=1
+IDENTITY_HEADER=X-NYPL-Identity
+TIME_ZONE=America/New_York
+SCHEMA_BASE_URL=https://dev-platform.nypl.org/api/v0.1/current-schemas
+API_BASE_URL=https://dev-platform.nypl.org/api/v0.1/
+SWAGGER_SCHEME=http
+SWAGGER_GENERAL_URL=http://dev-platformdocs.nypl.org/docs/checkout-requests
+SWAGGER_HOST=dev-platformdocs.nypl.org

--- a/config/var_production.env
+++ b/config/var_production.env
@@ -1,0 +1,20 @@
+SLACK_TOKEN=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAIgwgYUGCSqGSIb3DQEHBqB4MHYCAQAwcQYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAxeWC9l6ZvtQ7iqLyUCARCARLLDyTzUm24WUeZpsMIaUmqQXO/XWxRAkNbPpAyMdl3LZMxMFrVicQo0rmpQkJ8XJM7lSOslKMPdhllBGZxN7AuY7TX2
+DB_PASSWORD=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAGcwZQYJKoZIhvcNAQcGoFgwVgIBADBRBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDK5bU3fj4rxMk1LWYAIBEIAkI2zEkWAXLgXj5r9r3Wz4vz3E8F5b5CFHU65Jrwv9NYUFhECS
+DB_USERNAME=checkout_prod
+# These parameters should be left in plain text
+DB_CONNECT_STRING=pgsql:host=checkout-requests-production.cvy7z512hcjg.us-east-1.rds.amazonaws.com;dbname=checkout_requests
+NCIP_URL=AQECAHh7ea2tyZ6phZgT4B9BDKwguhlFtRC6hgt+7HbmeFsrsgAAAI8wgYwGCSqGSIb3DQEHBqB/MH0CAQAweAYJKoZIhvcNAQcBMB4GCWCGSAFlAwQBLjARBAyRpBfd/dYPpJReZ0sCARCAS2CdOrSKZenlt+x9HNE+6IrvOajQbcqDuFjTfyJHJ8sphsH+7TBXNPT/HTG8P7Lccuzup/iuDzj2gDttba+HOH3HacfRcmBGCQ9Lzw==
+SLACK_CHANNEL=service-logging
+SLACK_CHANNEL_ALT=cancel-req-logging
+SLACK_USERNAME=CheckoutRequestService-production
+SLACK_LOGGING_LEVEL=info
+DEFAULT_LOGGING_LEVEL=debug
+JOB_SERVICE_URL=https://platform.nypl.org/api/v0.1/jobs
+USE_JOB_SERVICE=1
+IDENTITY_HEADER=X-NYPL-Identity
+TIME_ZONE=America/New_York
+SCHEMA_BASE_URL=https://platform.nypl.org/api/v0.1/current-schemas
+API_BASE_URL=https://platform.nypl.org/api/v0.1/
+SWAGGER_SCHEME=https
+SWAGGER_GENERAL_URL=http://platformdocs.nypl.org/docs/checkout-requests
+SWAGGER_HOST=platformdocs.nypl.org

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "pretest": "phplint src/*.php src/**/*.php src/**/**/*.php",
     "test": "node-lambda run -j config/event_sources_testing.json -f config/var_testing.env",
-    "deploy-development": "./node_modules/.bin/node-lambda deploy -e development -f config/var_development.env -o arn:aws:iam::224280085904:role/lambda_basic_execution -b subnet-f4fe56af -g sg-1d544067 -a $AWS_ACCESS_KEY_ID_DEVELOPMENT -s $AWS_SECRET_ACCESS_KEY_DEVELOPMENT",
-    "deploy-production": "./node_modules/.bin/node-lambda deploy -e production -f config/var_production.env -o arn:aws:iam::224280085904:role/lambda_basic_execution -b subnet-f4fe56af -g sg-1d544067 -a $AWS_ACCESS_KEY_ID_PRODUCTION -s $AWS_SECRET_ACCESS_KEY_PRODUCTION"
+    "deploy-development": "./node_modules/.bin/node-lambda deploy -e development -f config/var_development.env -o arn:aws:iam::224280085904:role/lambda_basic_execution -b subnet-f4fe56af -g sg-1d544067 --profile nypl-sandbox",
+    "deploy-production": "./node_modules/.bin/node-lambda deploy -e production -f config/var_production.env -o arn:aws:iam::946183545209:role/lambda-full-access -b subnet-f4fe56af -g sg-1d544067 --profile nypl-digital-dev",
   },
   "repository": {},
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pretest": "phplint src/*.php src/**/*.php src/**/**/*.php",
     "test": "node-lambda run -j config/event_sources_testing.json -f config/var_testing.env",
     "deploy-development": "./node_modules/.bin/node-lambda deploy -e development -f config/var_development.env -o arn:aws:iam::224280085904:role/lambda_basic_execution -b subnet-f4fe56af -g sg-1d544067 --profile nypl-sandbox",
-    "deploy-production": "./node_modules/.bin/node-lambda deploy -e production -f config/var_production.env -o arn:aws:iam::946183545209:role/lambda-full-access -b subnet-f4fe56af -g sg-1d544067 --profile nypl-digital-dev",
+    "deploy-production": "./node_modules/.bin/node-lambda deploy -e production -f config/var_production.env -o arn:aws:iam::946183545209:role/lambda-full-access -b subnet-f4fe56af -g sg-1d544067 --profile nypl-digital-dev"
   },
   "repository": {},
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "CheckoutRequestService",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Lambda for the NYPL Checkout Request Service",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "scripts": {
     "pretest": "phplint src/*.php src/**/*.php src/**/**/*.php",
     "test": "node-lambda run -j config/event_sources_testing.json -f config/var_testing.env",
-    "deploy-development": "node-lambda deploy -e development -f config/var_development.env -S config/event_sources_development.json -b {subnets} -g {security-groups}",
-    "deploy-qa": "node-lambda deploy -e qa -f config/var_qa.env -S config/event_sources_qa.json -b {subnets} -g {security-groups}",
-    "deploy-production": "node-lambda deploy -e production -f config/var_production.env -S config/event_sources_production.json -b {subnets} -g {security-groups}"
+    "deploy-development": "./node_modules/.bin/node-lambda deploy -e development -f config/var_development.env -o arn:aws:iam::224280085904:role/lambda_basic_execution -b subnet-f4fe56af -g sg-1d544067 -a $AWS_ACCESS_KEY_ID_DEVELOPMENT -s $AWS_SECRET_ACCESS_KEY_DEVELOPMENT",
+    "deploy-production": "./node_modules/.bin/node-lambda deploy -e production -f config/var_production.env -o arn:aws:iam::224280085904:role/lambda_basic_execution -b subnet-f4fe56af -g sg-1d544067 -a $AWS_ACCESS_KEY_ID_PRODUCTION -s $AWS_SECRET_ACCESS_KEY_PRODUCTION"
   },
   "repository": {},
   "keywords": [],
   "dependencies": {},
-  "devDependencies": {}
+  "devDependencies": {
+    "node-lambda": "0.12.0"
+  }
 }

--- a/scripts/travis-deploy.sh
+++ b/scripts/travis-deploy.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This script is called by Travis to deploy the app for a named environment.
+# It derives the deploy command from package.json, replaces --profile with
+# relevant AWS_ environment variables, and executes the resulting command.
+
+# Fail if ENVIRONMENT param invalid:
+if ! [[ $1 =~ ^(development|qa|production) ]] ; then
+  echo Aborting travis-deploy. Must specify ENVIRONMENT.
+  echo Usage: ./scripts/travis-deploy ENVIRONMENT
+  echo "  Where ENVIRONMENT is (development|qa|production)"
+  exit
+fi
+
+ENVIRONMENT_NAME=$1
+ENVIRONMENT_CAPS=$(echo $ENVIRONMENT_NAME | awk '{print toupper($0)}')
+
+# Extract relevant deploy script from package.json:
+DEPLOY_CMD=$(cat package.json | jq ".scripts | .\"deploy-$ENVIRONMENT_NAME\"" --raw-output)
+
+# Replace --profile in command with environment-specific environment variables
+# known to be set in travis:
+DEPLOY_CMD=$(echo "$DEPLOY_CMD" | sed "s/ --profile [a-z-]*/ -a \$AWS_ACCESS_KEY_ID_$ENVIRONMENT_CAPS -s \$AWS_SECRET_ACCESS_KEY_$ENVIRONMENT_CAPS/g")
+
+echo Running deploy command for "$ENVIRONMENT_NAME" environment:
+echo "  $DEPLOY_CMD"
+
+# Execute command:
+eval $DEPLOY_CMD

--- a/src/NCIPClient.php
+++ b/src/NCIPClient.php
@@ -120,7 +120,7 @@ class NCIPClient
     public static function initializeClient()
     {
         self::setClient(new Client([
-            'base_uri' => Config::get('NCIP_URL'),
+            'base_uri' => Config::get('NCIP_URL', null, true),
             'timeout' => self::CLIENT_TIMEOUT,
             'headers' => [
                 'Content-Type' => 'application/xml'


### PR DESCRIPTION
This PR updates .travis.yml and .env related files for adding CI/CD mechanism to Checkout service. After the updates, we should be able to deploy this Lambda service by simply pushing development or master branch to remote.

development branch => development (nypl-sandbox)
master branch => production (nypl-digital-dev)

For making this work, we have to include some env files for Travis to run the tests. And due to that, all the sensitive data are now encrypted. And because of this, in file `src/NCIPClient.php` we have to tell the function `Config::get` that `NCIP_URL` is encrypted, thus we need to pass some additional parameters to the function.

@nonword and @danamansana I noticed that you are working on another PR for Checkout. To avoid stepping on your toe, I am including you here. Can you help me check and make sure this PR won't get in the way of what you are working on?